### PR TITLE
Fix Exception thrown at ObjectSerializer::toString()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3|^7.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.10.*",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.3|^7.*"
+        "guzzlehttp/guzzle": "^6.3|7.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.10.*",

--- a/src/GroupDocs/Conversion/ObjectSerializer.php
+++ b/src/GroupDocs/Conversion/ObjectSerializer.php
@@ -176,8 +176,7 @@ class ObjectSerializer
         }
         
         if (date(\DATE_ATOM, $matches[0]) instanceof \DateTime) { // datetime in ISO8601 format
-            $datetime = $matches[0];
-            return date(\DATE_ATOM, $datetime);
+            return date(\DATE_ATOM, $matches[0]);
         }
 
         return $value;

--- a/src/GroupDocs/Conversion/ObjectSerializer.php
+++ b/src/GroupDocs/Conversion/ObjectSerializer.php
@@ -169,12 +169,15 @@ class ObjectSerializer
      */
     public static function toString($value)
     {
-        if (date(\DATE_ATOM, preg_match("/^[1-9][0-9]*$/", $value)[0]) instanceof \DateTime) { // datetime in ISO8601 format
-            $datetime = preg_match("/^[1-9][0-9]*$/", $value)[0];
-            return date(\DATE_ATOM, $datetime);
-        } else {
+        try {
+            if (date(\DATE_ATOM, preg_match("/^[1-9][0-9]*$/", $value)[0]) instanceof \DateTime) { // datetime in ISO8601 format
+                $datetime = preg_match("/^[1-9][0-9]*$/", $value)[0];
+                return date(\DATE_ATOM, $datetime);
+            }
+        } catch (\Exception $e) {
             return $value;
         }
+        return $value;
     }
 
     /*

--- a/src/GroupDocs/Conversion/ObjectSerializer.php
+++ b/src/GroupDocs/Conversion/ObjectSerializer.php
@@ -169,14 +169,17 @@ class ObjectSerializer
      */
     public static function toString($value)
     {
-        try {
-            if (date(\DATE_ATOM, preg_match("/^[1-9][0-9]*$/", $value)[0]) instanceof \DateTime) { // datetime in ISO8601 format
-                $datetime = preg_match("/^[1-9][0-9]*$/", $value)[0];
-                return date(\DATE_ATOM, $datetime);
-            }
-        } catch (\Exception $e) {
+        preg_match("/^[1-9][0-9]*$/", $value, $matches);
+
+        if (empty($matches)) {
             return $value;
         }
+        
+        if (date(\DATE_ATOM, $matches[0]) instanceof \DateTime) { // datetime in ISO8601 format
+            $datetime = $matches[0];
+            return date(\DATE_ATOM, $datetime);
+        }
+
         return $value;
     }
 


### PR DESCRIPTION
This pull request fixes an exception that was thrown by `ObjectSerializer::toString()`, caused by incorrect use of preg_match.
I don't think this function works as expected though, because the result of `date()` is always a string and never an instance of \DataTime.


Also, Guzzle 7 is allowed now.